### PR TITLE
Preserve fperm

### DIFF
--- a/debian/index.go
+++ b/debian/index.go
@@ -980,7 +980,11 @@ func cp(dst, src string) error {
 		return err
 	}
 	defer s.Close()
-	d, err := os.Create(dst)
+	stat, err := s.Stat()
+	if err != nil {
+		return err
+	}
+	d, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, stat.Mode())
 	if err != nil {
 		return err
 	}

--- a/debian/index.go
+++ b/debian/index.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/groove-x/go-bin-deb/stringexec"
 	"github.com/mattn/go-zglob"
-	"github.com/mh-cbon/go-bin-deb/stringexec"
 	"github.com/mh-cbon/verbose"
 )
 

--- a/go-bin-deb-utils/utils.go
+++ b/go-bin-deb-utils/utils.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mh-cbon/go-bin-deb/stringexec"
+	"github.com/groove-x/go-bin-deb/stringexec"
 )
 
 func maybesudo(w string, params ...interface{}) error {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/mh-cbon/go-bin-deb/debian"
+	"github.com/groove-x/go-bin-deb/debian"
 	"github.com/mh-cbon/verbose"
 	"github.com/urfave/cli"
 )


### PR DESCRIPTION
Formerly the installed files' permission was not copied from original files. This patch enables it to copy the file permission so that we don't need specify fperm on every file.

In addition, I've changed the import paths which imports `github.com/mh-cbon/go-bin-deb/*` to our one.