### PR TITLE
feat: symlinkを含むディレクトリでdebパッケージを作る

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+PROJECT_DIR := $(patsubst %/,%,$(dir $(mkfile_path)))
+
+ARCH?=amd64
+
+BIN?=${PROJECT_DIR}/go-bin-deb
+TEST_DEB?=hello-${ARCH}.deb
+TEST_DEB_FILE?=demo/${TEST_DEB}
+
+echo:
+	@echo "PROJECT_DIR: ${PROJECT_DIR}"
+	@echo "BIN: ${BIN}"
+	@echo "TEST_DEB: ${TEST_DEB}"
+
+build: ${BIN}
+${BIN}:
+	@echo 
+	@echo "go-bin-debをビルド"
+	@echo 
+	go build
+
+test: build
+	make ${TEST_DEB_FILE}
+
+	@echo 
+	@echo "debファイルに期待する中身があることを確認"
+	@echo 
+	@echo "expect: symlinkが2件含まれている"
+	@dpkg -c demo/hello-amd64.deb | grep "asset -> /usr/share/hello/other/asset1"
+
+${TEST_DEB_FILE}:
+	@echo 
+	@echo "demoディレクトリの内容をパッケージにできるかテスト"
+	@echo 
+	cd demo && \
+		GOOS=linux GOARCH=${ARCH} go build -o build/${ARCH}/hello hello.go && \
+		${BIN} generate -a ${ARCH} --version 0.0.1 -w pkg-build/${ARCH}/ -o ${TEST_DEB}
+
+clean:
+	rm -rf ${BIN}
+	rm -rf demo/pkg-build
+	rm -rf demo/build
+	rm -rf demo/*.deb

--- a/debian/index.go
+++ b/debian/index.go
@@ -518,13 +518,21 @@ func (d *Package) ImportFiles(sourceDir string) error {
 				return errors.New(m)
 			}
 			if s.IsDir() == false {
-				if err := cp(targetItems[i], item); err != nil {
-					m := fmt.Sprintf("Could not copy file from '%s' to '%s': %s", item, targetItems[i], err.Error())
-					return errors.New(m)
-				}
-				if fileInst.Fperm != "" {
-					if err := os.Chmod(targetItems[i], os.FileMode(fperm)); err != nil {
-						return err
+				if symlink, err := isSymlink(item); err == nil && symlink {
+					err := cpSymlink(targetItems[i], item)
+					if err != nil {
+						m := fmt.Sprintf("Could not copy symlink from '%s' to '%s': %s", item, targetItems[i], err.Error())
+						return errors.New(m)
+					}
+				} else {
+					if err := cp(targetItems[i], item); err != nil {
+						m := fmt.Sprintf("Could not copy file from '%s' to '%s': %s", item, targetItems[i], err.Error())
+						return errors.New(m)
+					}
+					if fileInst.Fperm != "" {
+						if err := os.Chmod(targetItems[i], os.FileMode(fperm)); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -598,7 +606,7 @@ func (d *Package) WriteControlFile(debianDir string, size uint64) error {
 	P += strAppend("Provides", d.Provides)
 	P += strAppend("Replaces", d.Replaces)
 	P += strAppend("Built-Using", d.BuiltUsing)
-	P += strAppend("Installed-Size", strconv.FormatUint(size,10))
+	P += strAppend("Installed-Size", strconv.FormatUint(size, 10))
 	P += strAppend("Package-Type", d.PackageType)
 
 	controlContent := []byte(P)
@@ -993,6 +1001,34 @@ func cp(dst, src string) error {
 		return err
 	}
 	return d.Close()
+}
+
+func cpSymlink(dst, src string) error {
+	link, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+
+	// remove file if exists
+	if _, err := os.Lstat(dst); err == nil {
+		err := os.Remove(dst)
+		if err != nil {
+			return err
+		}
+	}
+	return os.Symlink(link, dst)
+}
+
+func isSymlink(s string) (bool, error) {
+	info, err := os.Lstat(s)
+	if err != nil {
+		return false, err
+	}
+
+	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		return true, nil
+	}
+	return false, nil
 }
 
 func contains(s []string, v string) bool {

--- a/debian/index.go
+++ b/debian/index.go
@@ -551,9 +551,9 @@ func (d *Package) ComputeSize(sourceDir string) (int64, error) {
 		//   return nil
 		// }
 		if err == nil {
-			s, _ := os.Stat(path)
+			s, err := os.Lstat(path)
 			if err == nil {
-				if s.IsDir() == false {
+				if !s.IsDir() {
 					size += s.Size()
 				}
 			}

--- a/debian/index.go
+++ b/debian/index.go
@@ -493,7 +493,7 @@ func (d *Package) ImportFiles(sourceDir string) error {
 		}
 		logger.Printf("targetItems=%q\n", targetItems)
 		for i, item := range items {
-			s, err := os.Stat(item)
+			s, err := os.Lstat(item)
 			if err != nil {
 				m := fmt.Sprintf("Could not stat source file '%s': %s", item, err.Error())
 				return errors.New(m)
@@ -512,12 +512,12 @@ func (d *Package) ImportFiles(sourceDir string) error {
 			}
 		}
 		for i, item := range items {
-			s, err := os.Stat(item)
+			s, err := os.Lstat(item)
 			if err != nil {
 				m := fmt.Sprintf("Could not stat source file '%s': %s", item, err.Error())
 				return errors.New(m)
 			}
-			if s.IsDir() == false {
+			if !s.IsDir() {
 				if symlink, err := isSymlink(item); err == nil && symlink {
 					err := cpSymlink(targetItems[i], item)
 					if err != nil {

--- a/demo/assets/asset
+++ b/demo/assets/asset
@@ -1,0 +1,1 @@
+/usr/share/hello/other/asset1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,16 @@
+module github.com/groove-x/go-bin-deb
+
+go 1.20
+
+require (
+	github.com/mattn/go-zglob v0.0.0-20160607002833-2dbd7f37a45e
+	github.com/mh-cbon/verbose v0.0.0-20160711150219-2b8e4118ca07
+	github.com/urfave/cli v1.18.0
+)
+
+require (
+	github.com/fatih/color v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.0.5 // indirect
+	github.com/mattn/go-isatty v0.0.0-20151211000621-56b76bdf51f7 // indirect
+	golang.org/x/sys v0.0.0-20160704031755-a408501be4d1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/fatih/color v1.0.0 h1:4zdNjpoprR9fed2QRCPb2VTPU4UFXEtJc9Vc+sgXkaQ=
+github.com/fatih/color v1.0.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/mattn/go-colorable v0.0.5 h1:X1IeP+MaFWC+vpbhw3y426rQftzXSj+N7eJFnBEMBfE=
+github.com/mattn/go-colorable v0.0.5/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.0-20151211000621-56b76bdf51f7 h1:owMyzMR4QR+jSdlfkX9jPU3rsby4++j99BfbtgVr6ZY=
+github.com/mattn/go-isatty v0.0.0-20151211000621-56b76bdf51f7/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-zglob v0.0.0-20160607002833-2dbd7f37a45e h1:CKUOoFXxmNBWmFTR23znmpAl2WMnDWd/FMjHuSw6mNg=
+github.com/mattn/go-zglob v0.0.0-20160607002833-2dbd7f37a45e/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
+github.com/mh-cbon/verbose v0.0.0-20160711150219-2b8e4118ca07 h1:TY5IdR1j46GCDiVVfs7Oc9JgpJoA2AmNPRH4oF9cX+g=
+github.com/mh-cbon/verbose v0.0.0-20160711150219-2b8e4118ca07/go.mod h1:oCHJllkeMGmtEJYsuGRMCY0XbgXHyOSZPxKD6O+rHoo=
+github.com/urfave/cli v1.18.0 h1:m9MfmZWX7bwr9kUcs/Asr95j0IVXzGNNc+/5ku2m26Q=
+github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+golang.org/x/sys v0.0.0-20160704031755-a408501be4d1 h1:QtO5ZFD1u7KisZhuRLL2GaZAZDdJqUcTdjFJj8OEePA=
+golang.org/x/sys v0.0.0-20160704031755-a408501be4d1/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
## Why

インストール後にパスが通る`symlink`を含むファイルをビルドする場合、ビルド環境にファイル実体がなくてdebパッケージが作れない不具合があった。

## What

- symlinkの場合はリンク情報をコピーする仕様に変更しました。
- Goのバージョン更新に合わせて`go.mod`を追加しました
- demoにsymlinkをおいて、期待通りになるかテストを追加しました。 `make test`で動作します。