### PR TITLE
support yaml format

### DIFF
--- a/debian/index.go
+++ b/debian/index.go
@@ -12,9 +12,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/groove-x/go-bin-deb/stringexec"
 	"github.com/mattn/go-zglob"
 	"github.com/mh-cbon/verbose"
+	"gopkg.in/yaml.v2"
+
+	"github.com/groove-x/go-bin-deb/stringexec"
 )
 
 var logger = verbose.Auto()
@@ -104,21 +106,34 @@ type Package struct {
 	Menus               []menu             `json:"menus"`                // Desktop shortcuts
 }
 
-// Load given deb.json file
+// Load given deb.json or deb.yml file
 func (d *Package) Load(file string) error {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		m := fmt.Sprintf("json file '%s' does not exist: %s", file, err.Error())
+		m := fmt.Sprintf("file '%s' does not exist: %s", file, err.Error())
 		return errors.New(m)
 	}
 	byt, err := ioutil.ReadFile(file)
 	if err != nil {
-		m := fmt.Sprintf("error occured while reading file '%s': %s", file, err.Error())
+		m := fmt.Sprintf("error occurred while reading file '%s': %s", file, err.Error())
 		return errors.New(m)
 	}
-	if err := json.Unmarshal(byt, d); err != nil {
-		m := fmt.Sprintf("Invalid json file '%s': %s", file, err.Error())
+
+	switch filepath.Ext(file) {
+	case ".json":
+		if err := json.Unmarshal(byt, d); err != nil {
+			m := fmt.Sprintf("Invalid JSON file '%s': %s", file, err.Error())
+			return errors.New(m)
+		}
+	case ".yml", ".yaml":
+		if err := yaml.Unmarshal(byt, d); err != nil {
+			m := fmt.Sprintf("Invalid YAML file '%s': %s", file, err.Error())
+			return errors.New(m)
+		}
+	default:
+		m := fmt.Sprintf("Unsupported file format '%s'", file)
 		return errors.New(m)
 	}
+
 	return nil
 }
 

--- a/debian/index.go
+++ b/debian/index.go
@@ -60,7 +60,7 @@ type menu struct {
 	MimeType        string `json:"mime-type"`      // ; separated list
 }
 
-// Package contaisn informtation about a debian package to build
+// Package contains information about a debian package to build
 type Package struct {
 	Name                string             `json:"name"`                 // Name of the package
 	Maintainer          string             `json:"maintainer"`           // Information of the package maintainer

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/mattn/go-zglob v0.0.0-20160607002833-2dbd7f37a45e
 	github.com/mh-cbon/verbose v0.0.0-20160711150219-2b8e4118ca07
 	github.com/urfave/cli v1.18.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,7 @@ github.com/urfave/cli v1.18.0 h1:m9MfmZWX7bwr9kUcs/Asr95j0IVXzGNNc+/5ku2m26Q=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 golang.org/x/sys v0.0.0-20160704031755-a408501be4d1 h1:QtO5ZFD1u7KisZhuRLL2GaZAZDdJqUcTdjFJj8OEePA=
 golang.org/x/sys v0.0.0-20160704031755-a408501be4d1/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 				cli.StringFlag{
 					Name:  "file, f",
 					Value: "deb.json",
-					Usage: "Path to the deb.json file",
+					Usage: "Path to the deb.json,deb.yml,deb.yaml file",
 				},
 				cli.StringFlag{
 					Name:  "version",
@@ -64,7 +64,7 @@ func main() {
 				cli.StringFlag{
 					Name:  "file, f",
 					Value: "deb.json",
-					Usage: "Path to the deb.json file",
+					Usage: "Path to the deb.json,deb.yml,deb.yaml file",
 				},
 			},
 		},
@@ -93,20 +93,20 @@ func generateContents(c *cli.Context) error {
 		return cli.NewExitError(fmt.Sprintf("unsupported file format: %s. only .json, .yaml, and .yml are supported.", ext), 1)
 	}
 
-	debJSON := debian.Package{}
+	packageInfo := debian.Package{}
 
-	// load the deb.json file
-	if err := debJSON.Load(file); err != nil {
+	// load the deb.json,deb.yml,deb.yaml file
+	if err := packageInfo.Load(file); err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
-	logger.Println("deb.json loaded")
+	logger.Println(fmt.Sprintf("%s loaded", file))
 
 	// normalize data
-	debJSON.Normalize(pkgDir, version, arch)
+	packageInfo.Normalize(pkgDir, version, arch)
 	logger.Println("pkg data normalized")
 
 	logger.Printf("Generating files in %s", pkgDir)
-	if err := debJSON.GenerateFiles(filepath.Dir(file), pkgDir); err != nil {
+	if err := packageInfo.GenerateFiles(filepath.Dir(file), pkgDir); err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
@@ -129,9 +129,9 @@ func testPkg(c *cli.Context) error {
 		return cli.NewExitError(fmt.Sprintf("unsupported file format: %s. only .json, .yaml, and .yml are supported.", ext), 1)
 	}
 
-	debJSON := debian.Package{}
+	packageInfo := debian.Package{}
 
-	if err := debJSON.Load(file); err != nil {
+	if err := packageInfo.Load(file); err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -7,9 +7,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/groove-x/go-bin-deb/debian"
 	"github.com/mh-cbon/verbose"
 	"github.com/urfave/cli"
+
+	"github.com/groove-x/go-bin-deb/debian"
 )
 
 // VERSION is the last build number.
@@ -87,6 +88,11 @@ func generateContents(c *cli.Context) error {
 		output = o
 	}
 
+	// Check if the file has a supported extension
+	if ext := filepath.Ext(file); ext != ".json" && ext != ".yaml" && ext != ".yml" {
+		return cli.NewExitError(fmt.Sprintf("unsupported file format: %s. only .json, .yaml, and .yml are supported.", ext), 1)
+	}
+
 	debJSON := debian.Package{}
 
 	// load the deb.json file
@@ -117,6 +123,11 @@ func generateContents(c *cli.Context) error {
 
 func testPkg(c *cli.Context) error {
 	file := c.String("file")
+
+	// Check if the file has a supported extension
+	if ext := filepath.Ext(file); ext != ".json" && ext != ".yaml" && ext != ".yml" {
+		return cli.NewExitError(fmt.Sprintf("unsupported file format: %s. only .json, .yaml, and .yml are supported.", ext), 1)
+	}
 
 	debJSON := debian.Package{}
 


### PR DESCRIPTION
Support yaml format.

Usage example: `go-bin-deb generate --version 0.0.1 --file deb.yml`
