### PR TITLE
Add a compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,12 @@ USAGE:
    go-bin-deb generate [command options] [arguments...]
 
 OPTIONS:
-   --wd value, -w value      Working directory to prepare the package (default: "pkg-build")
-   --output value, -o value  Output directory for the debian package files
-   --file value, -f value    Path to the deb.json file (default: "deb.json")
-   --version value           Version of the package
-   --arch value, -a value    Arch of the package
+   --wd value, -w value           Working directory to prepare the package (default: "pkg-build")
+   --output value, -o value       Output directory for the debian package files
+   --file value, -f value         Path to the deb.json file (default: "deb.json")
+   --version value                Version of the package
+   --arch value, -a value         Arch of the package
+   --compression value, -z value  Compression to use (via dpkg-deb -Z)
 ```
 
 ### test

--- a/main.go
+++ b/main.go
@@ -54,6 +54,11 @@ func main() {
 					Value: "",
 					Usage: "Arch of the package",
 				},
+				cli.StringFlag{
+					Name:  "compression, z",
+					Value: "",
+					Usage: "Compression to use (via dpkg-deb -Z)",
+				},
 			},
 		},
 		{
@@ -79,6 +84,7 @@ func generateContents(c *cli.Context) error {
 	file := c.String("file")
 	version := c.String("version")
 	arch := c.String("arch")
+	compression := c.String("compression")
 
 	pkgDir := filepath.Join(wd)
 
@@ -110,8 +116,14 @@ func generateContents(c *cli.Context) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
-	logger.Printf("Building package in %s to %s", wd, output)
-	if err := buildPackage(pkgDir, output); err != nil {
+	extraArgs := []string{}
+	if compression != "" {
+		extraArgs = append(extraArgs, "-Z"+compression)
+		logger.Printf("Building package in %s to %s with compression %v", wd, output, compression)
+	} else {
+		logger.Printf("Building package in %s to %s", wd, output)
+	}
+	if err := buildPackage(pkgDir, output, extraArgs); err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
@@ -140,8 +152,13 @@ func testPkg(c *cli.Context) error {
 	return nil
 }
 
-func buildPackage(wd string, output string) error {
-	oCmd := exec.Command("fakeroot", "dpkg-deb", "--build", "debian", output)
+func buildPackage(wd string, output string, extraArgs []string) error {
+	args := []string{"dpkg-deb"}
+	if len(extraArgs) > 0 {
+		args = append(args, extraArgs...)
+	}
+	args = append(args, "--build", "debian", output)
+	oCmd := exec.Command("fakeroot", args...)
 	oCmd.Dir = wd
 	oCmd.Stdout = os.Stdout
 	oCmd.Stderr = os.Stderr


### PR DESCRIPTION
## What
The new option `-z/--compression` allows you to specify the compression on the command line. If you do not use the new setting, then the default value from `dpkg-deb` will be used, just the same as before.

## Why
In order to target older operating systems, we need to be able to set the compression to something that they'll suport, such as `xz`. For example, these days, `zstd` is the default, but that won't work on older systems.

This PR is based off of a PR for the upstream https://github.com/mh-cbon/go-bin-deb/pull/14 and I've adjusted some seasoning. Kudos to the original author.